### PR TITLE
Create GitHub Action for build automation

### DIFF
--- a/.github/workflows/Build_Launcher.yml
+++ b/.github/workflows/Build_Launcher.yml
@@ -1,0 +1,40 @@
+name: Build WoW-Launcher
+
+on: ['push']
+
+env:
+  DOTNET_VERSION: '6.0.x'
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: ['windows'] # TODO macos
+        arch: ['x64'] # TODO Add ARM64 but GitHub Actions currently does not support ARM :(
+        configuration: ['Release', 'ReleaseCustomFiles', 'ReleaseSilentMode', 'ReleaseCustomFilesSilentMode']
+    runs-on: ${{ matrix.os }}-latest
+
+    steps:
+      - name: Checkout repository content
+        uses: actions/checkout@v3
+
+      - name: Setup .NET Core SDK
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Install dependencies
+        run: dotnet restore
+
+      - name: Build/Publish
+        run: dotnet publish --configuration ${{ matrix.configuration }} /p:Platform="${{ matrix.arch }}" --use-current-runtime -p:UsePublishBuildSettings=true
+
+      - name: Copy files
+        run: cp -r ./build/${{ matrix.configuration }}/bin/*/publish/ publish
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: WoW-Launcher-${{ matrix.configuration }}-${{ matrix.os }}-${{ matrix.arch }}-${{ github.sha }}
+          path: publish
+          if-no-files-found: error

--- a/src/Arctium.WoW.Launcher.csproj
+++ b/src/Arctium.WoW.Launcher.csproj
@@ -26,11 +26,14 @@
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Platform)'=='x64'">
-		<RuntimeIdentifier>win-x64</RuntimeIdentifier>
+		<RuntimeIdentifier Condition="$([MSBuild]::IsOSPlatform('Windows'))">win-x64</RuntimeIdentifier>
+		<TargetFrameworkA>net8.0</TargetFrameworkA>
+		<RuntimeIdentifier Condition="$([MSBuild]::IsOSPlatform('OSX'))">osx-x64</RuntimeIdentifier>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Platform)'=='ARM64'">
-		<RuntimeIdentifier>win-arm64</RuntimeIdentifier>
+		<RuntimeIdentifier Condition="$([MSBuild]::IsOSPlatform('Windows'))">win-arm64</RuntimeIdentifier>
+		<RuntimeIdentifier Condition="$([MSBuild]::IsOSPlatform('OSX'))">osx-arm64</RuntimeIdentifier>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)'=='Debug'">


### PR DESCRIPTION
Testing if all configurations can be build
and creates artifacts (example: https://github.com/0blu/WoW-Launcher/actions/runs/3389924426)

Would be cool if the `static-auth-seed` could be merged too (_toggled by Configuration_).